### PR TITLE
Add Umbrella

### DIFF
--- a/src/_data/starters/umbrella.json
+++ b/src/_data/starters/umbrella.json
@@ -1,0 +1,7 @@
+{
+	"url": "https://github.com/benjifs/umbrella",
+	"name": "umbrella",
+	"description": "11ty starter project with indieauth, micropub, and webmentions built in ",
+	"author": "benjifs",
+	"demo": "https://umbrella.sploot.com"
+}


### PR DESCRIPTION
The starter site itself is simple but its also using Netlify functions to add IndieAuth, Micropub, and Webmentions without external services. This allows the site to function as it's own authentication provider and use one of the many Micropub Clients to add content to it.

Demo: https://umbrella.sploot.com